### PR TITLE
Fix to Issue #25 - Not found error on iterator when over 1000 volumes

### DIFF
--- a/PyU4V/common.py
+++ b/PyU4V/common.py
@@ -558,7 +558,7 @@ class CommonFunctions(object):
         :return: list of results
         """
         page_list = []
-        target_uri = 'common/Iterator/{}/page'.format(iterator_id)
+        target_uri = '/common/Iterator/{}/page'.format(iterator_id)
         filters = {'from': start, 'to': end}
         response = self.get_request(target_uri, 'iterator', params=filters)
         if response and response.get('result'):

--- a/PyU4V/provisioning.py
+++ b/PyU4V/provisioning.py
@@ -1328,7 +1328,7 @@ class ProvisioningFunctions(object):
                         end = count
                     vol_page = self.common.get_iterator_page_list(
                         iterator_id, start, end)
-                    for vol in vol_page['result']:
+                    for vol in vol_page:
                         vol_id_list.append(vol['volumeId'])
             else:
                 for vol in response['resultList']['result']:


### PR DESCRIPTION
I ran into this issue as well and found what appeared to be a missing / on line 561 of common.py and removed an issue on line 1331 of provisioning.py that looks for ['result'] but that attribute doesn't actually exist.  This path only gets exercised if your have multiple pages of data, which is why it worked for 1000 items or less.  Tested these changes in my local environment successfully on a system with >1000 vols and one with <1000 vols and it works.