### PR TITLE
Adding an option into create_storage_group for creating thick volumes

### DIFF
--- a/PyU4V/provisioning.py
+++ b/PyU4V/provisioning.py
@@ -940,7 +940,7 @@ class ProvisioningFunctions(object):
     def create_storage_group(self, srp_id, sg_id, slo, workload=None,
                              do_disable_compression=False,
                              num_vols=0, vol_size="0", cap_unit="GB",
-                             async=False,vol_name=None):
+                             allocate_full=False, async=False, vol_name=None):
         """Create the volume in the specified storage group.
 
         :param srp_id: the SRP (String)
@@ -951,6 +951,7 @@ class ProvisioningFunctions(object):
         :param num_vols: number of volumes to be created
         :param vol_size: the volume size
         :param cap_unit: the capacity unit (MB, GB, TB, CYL)
+        :param allocate_full: boolean to indicate if you want a thick volume
         :param async: Flag to indicate if call should be async
         :param vol_name: name to give to the volume, optional
         :returns: dict
@@ -976,6 +977,15 @@ class ProvisioningFunctions(object):
                     "volumeIdentifier": {
                         "identifier_name": vol_name,
                         "volumeIdentifierChoice": "identifier_name"}})
+
+            if allocate_full:
+                # If case of full volume allocation, we must set the
+                # noCompression parameter at true because fully
+                # allocations and compression are exclusive parameters
+                slo_param.update({"noCompression": "true"})
+                slo_param.update({"allocate_capacity_for_each_vol": "true"})
+                slo_param.update({"persist_preallocated_capacity_through_"
+                                  "reclaim_or_copy": "true"})
 
             payload.update({"sloBasedStorageGroupParam": [slo_param]})
 

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -1427,6 +1427,33 @@ class PyU4VProvisioningTest(testtools.TestCase):
                 self.data.array, 'sloprovisioning', 'storagegroup',
                 payload=payload1)
 
+    def test_create_storage_group_vol_name_allocated(self):
+        with mock.patch.object(
+                self.provisioning, 'create_resource') as mock_create:
+            # 1 - no slo, not async
+            self.provisioning.create_storage_group(
+                self.data.srp, 'new-sg', slo="Diamond", workload=None,
+                num_vols=1, vol_size="1", vol_name="ID4TEST")
+            payload1 = {
+                "srpId": "SRP_1",
+                "storageGroupId": 'new-sg',
+                "emulation": "FBA",
+                "sloBasedStorageGroupParam": [
+                    {"num_of_vols": 1,
+                     "sloId": "Diamond",
+                     "workloadSelection": None,
+                     "noCompression": "true",
+                     "persist_preallocated_capacity_through_reclaim_or_copy": "true",
+                     "allocate_capacity_for_each_vol": "true",
+                     "volumeIdentifier": {
+                         "identifier_name": "ID4TEST",
+                         "volumeIdentifierChoice": "identifier_name"},
+                     "volumeAttribute": {"volume_size": "1",
+                                         "capacityUnit": "GB"}}]}
+
+            mock_create.assert_called_once_with(
+                self.data.array, 'sloprovisioning', 'storagegroup',
+                payload=payload1)
 
     def test_create_non_empty_storagegroup(self):
         with mock.patch.object(


### PR DESCRIPTION
Hello,

I've added a little option into create_storage_group because, sometimes, we have to create thick volumes instead of thin (boot on SAN volumes for instance).

Best regards