### PR TITLE
Migration Endpoints

### DIFF
--- a/PyU4V/migration.py
+++ b/PyU4V/migration.py
@@ -1,0 +1,165 @@
+# The MIT License (MIT)
+# Copyright (c) 2016 Dell Inc. or its subsidiaries.
+
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""migration.py."""
+import logging
+
+from PyU4V.utils import constants
+
+LOG = logging.getLogger(__name__)
+
+MIGRATION = constants.MIGRATION
+ASYNC_UPDATE = constants.ASYNC_UPDATE
+
+
+class MigrationFunctions(object):
+    def __init__(self, array_id, request, common, u4v_version):
+        """__init__."""
+        self.array_id = array_id
+        self.common = common
+        self.request = request
+        self.U4V_VERSION = u4v_version
+        self.get_resource = self.common.get_resource
+        self.create_resource = self.common.create_resource
+        self.modify_resource = self.common.modify_resource
+        self.delete_resource = self.common.delete_resource
+
+    def get_migration_info(self):
+        """Return migration information for an array.
+
+        :return: dict
+        """
+        target_uri = '/{}/migration/symmetrix/{}'.format(self.U4V_VERSION, self.array_id)
+        return self.common.get_request(target_uri, 'migration info')
+
+    def get_array_migration_capabilities(self):
+        """Check what migration facilities are available.
+
+        :return: array_capabilities dict
+        """
+        array_capabilities = {}
+        target_uri = ("/{}/migration/capabilities/symmetrix".format(self.U4V_VERSION))
+        capabilities = self.common.get_request(target_uri, 'migration capabilities')
+        symm_list = capabilities.get('storageArrayCapability', []) if capabilities else []
+        for symm in symm_list:
+            if symm['arrayId'] == self.array_id:
+                array_capabilities = symm
+                break
+        return array_capabilities
+
+    # Environment endpoints
+    def get_environment_list(self):
+        """Get list of all environments.
+
+        :return: list of all environments
+        """
+        response = self.get_resource(self.array_id, MIGRATION, 'environment')
+        environment_list = response.get('arrayId', []) if response else []
+        return environment_list
+
+    def get_environment(self, environment_name):
+        """Given a name, return migration environment details.
+
+        :param environment_name: the name of the migration environment
+        returns: environment dict
+        """
+        return self.get_resource(self.array_id, MIGRATION, 'environment', resource_name=environment_name)
+
+    def delete_environment(self, environment_name):
+        """Given a name, delete the migration environment.
+
+        :param environment_name: the name of the environment
+        """
+        return self.delete_resource(self.array_id, MIGRATION, 'environment', resource_name=environment_name)
+
+    # Storage group endpoints
+    def get_storage_group_list(self, include_migrations=False):
+        """Get list of all storage groups.
+
+        :param include_migrations: return only storage groups with migration sessions
+        :return: list of storage groups or migrating storage groups
+        """
+        filters = {}
+        if include_migrations:
+            filters.update({'includeMigrations': True})
+        response = self.get_resource(self.array_id, MIGRATION, 'storagegroup', params=filters)
+        key = 'migratingName' if include_migrations else 'name'
+        storage_group_list = response.get(key, []) if response else []
+        return storage_group_list
+
+    def get_storage_group(self, storage_group_name):
+        """Given a name, return storage group details wrt migration.
+
+        :param storage_group_name: the name of the storage group
+        :returns: storage group dict
+        """
+        return self.get_resource(self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name)
+
+    def create_storage_group_migration(
+            self, storage_group_name, target_array_id, srp_id=None, port_group_id=None,
+            no_compression=None, pre_copy=None, validate=None):
+        """Create a migration session for a storage group.
+
+        :param storage_group_name: the name of the new storage group migration session
+        :param target_array_id: the id of the target array
+        :param srp_id: the id of the storage resource pool to use
+        :param port_group_id: the id of the port group to use
+        :param no_compression: boolean, whether or not to use compression
+        :param pre_copy: boolean, whether or not to pre copy
+        :param validate: boolean, whether or not to validate
+        :return: the new storage group dict
+        """
+        payload = {"otherArrayId": target_array_id}
+        if srp_id:
+            payload.update({'srpId': srp_id})
+        if port_group_id:
+            payload.update({'portGroupId': port_group_id})
+        if no_compression:
+            payload.update({'noCompression': no_compression})
+        if pre_copy:
+            payload.update({'preCopy': pre_copy})
+        if validate:
+            payload.update({'validate': validate})
+        return self.create_resource(self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name, payload=payload)
+
+    def modify_storage_group_migration(self, storage_group_name, action, options=None, _async=False):
+        """Modify the state of a storage group's migration session.
+
+        :param storage_group_name: name of the storage group
+        :param action: the migration action e.g. Cutover, Sync, Commit, Recover, ReadyTgt
+        :param options: a dict of possible options - depends on action type, example
+        options={'cutover': {'force': True}}
+        :param _async: flag to indicate if call should be async
+        """
+        payload = {'action': action}
+        if options and action:
+            payload.update(options)
+        if _async:
+            payload.update(ASYNC_UPDATE)
+        return self.modify_resource(
+            self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name, payload=payload)
+
+    def delete_storage_group_migration(self, storage_group_name):
+        """Given a name, delete the storage group migration session.
+
+        :param storage_group_name: the name of the migrating storage group
+        """
+        self.delete_resource(self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name)

--- a/PyU4V/migration.py
+++ b/PyU4V/migration.py
@@ -63,8 +63,8 @@ class MigrationFunctions(object):
             self.U4V_VERSION))
         capabilities = self.common.get_request(
             target_uri, 'migration capabilities')
-        symm_list = capabilities.get('storageArrayCapability', []) \
-            if capabilities else []
+        symm_list = (capabilities.get('storageArrayCapability', [])
+            if capabilities else [])
         for symm in symm_list:
             if symm['arrayId'] == self.array_id:
                 array_capabilities = symm

--- a/PyU4V/migration.py
+++ b/PyU4V/migration.py
@@ -31,6 +31,8 @@ ASYNC_UPDATE = constants.ASYNC_UPDATE
 
 
 class MigrationFunctions(object):
+    """MigrationFunctions."""
+
     def __init__(self, array_id, request, common, u4v_version):
         """__init__."""
         self.array_id = array_id
@@ -47,7 +49,8 @@ class MigrationFunctions(object):
 
         :return: dict
         """
-        target_uri = '/{}/migration/symmetrix/{}'.format(self.U4V_VERSION, self.array_id)
+        target_uri = '/{}/migration/symmetrix/{}'.format(
+            self.U4V_VERSION, self.array_id)
         return self.common.get_request(target_uri, 'migration info')
 
     def get_array_migration_capabilities(self):
@@ -56,9 +59,12 @@ class MigrationFunctions(object):
         :return: array_capabilities dict
         """
         array_capabilities = {}
-        target_uri = ("/{}/migration/capabilities/symmetrix".format(self.U4V_VERSION))
-        capabilities = self.common.get_request(target_uri, 'migration capabilities')
-        symm_list = capabilities.get('storageArrayCapability', []) if capabilities else []
+        target_uri = ("/{}/migration/capabilities/symmetrix".format(
+            self.U4V_VERSION))
+        capabilities = self.common.get_request(
+            target_uri, 'migration capabilities')
+        symm_list = capabilities.get('storageArrayCapability', []) \
+            if capabilities else []
         for symm in symm_list:
             if symm['arrayId'] == self.array_id:
                 array_capabilities = symm
@@ -81,26 +87,31 @@ class MigrationFunctions(object):
         :param environment_name: the name of the migration environment
         returns: environment dict
         """
-        return self.get_resource(self.array_id, MIGRATION, 'environment', resource_name=environment_name)
+        return self.get_resource(
+            self.array_id, MIGRATION, 'environment',
+            resource_name=environment_name)
 
     def delete_environment(self, environment_name):
         """Given a name, delete the migration environment.
 
         :param environment_name: the name of the environment
         """
-        return self.delete_resource(self.array_id, MIGRATION, 'environment', resource_name=environment_name)
+        return self.delete_resource(
+            self.array_id, MIGRATION, 'environment',
+            resource_name=environment_name)
 
     # Storage group endpoints
     def get_storage_group_list(self, include_migrations=False):
         """Get list of all storage groups.
 
-        :param include_migrations: return only storage groups with migration sessions
+        :param include_migrations: return only SGs with migration sessions
         :return: list of storage groups or migrating storage groups
         """
         filters = {}
         if include_migrations:
             filters.update({'includeMigrations': True})
-        response = self.get_resource(self.array_id, MIGRATION, 'storagegroup', params=filters)
+        response = self.get_resource(
+            self.array_id, MIGRATION, 'storagegroup', params=filters)
         key = 'migratingName' if include_migrations else 'name'
         storage_group_list = response.get(key, []) if response else []
         return storage_group_list
@@ -111,14 +122,17 @@ class MigrationFunctions(object):
         :param storage_group_name: the name of the storage group
         :returns: storage group dict
         """
-        return self.get_resource(self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name)
+        return self.get_resource(
+            self.array_id, MIGRATION, 'storagegroup',
+            resource_name=storage_group_name)
 
     def create_storage_group_migration(
-            self, storage_group_name, target_array_id, srp_id=None, port_group_id=None,
-            no_compression=None, pre_copy=None, validate=None):
+            self, storage_group_name, target_array_id, srp_id=None,
+            port_group_id=None, no_compression=None, pre_copy=None,
+            validate=None):
         """Create a migration session for a storage group.
 
-        :param storage_group_name: the name of the new storage group migration session
+        :param storage_group_name: the name of the new SG migration session
         :param target_array_id: the id of the target array
         :param srp_id: the id of the storage resource pool to use
         :param port_group_id: the id of the port group to use
@@ -138,15 +152,19 @@ class MigrationFunctions(object):
             payload.update({'preCopy': pre_copy})
         if validate:
             payload.update({'validate': validate})
-        return self.create_resource(self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name, payload=payload)
+        return self.create_resource(
+            self.array_id, MIGRATION, 'storagegroup',
+            resource_name=storage_group_name, payload=payload)
 
-    def modify_storage_group_migration(self, storage_group_name, action, options=None, _async=False):
+    def modify_storage_group_migration(
+            self, storage_group_name, action, options=None, _async=False):
         """Modify the state of a storage group's migration session.
 
         :param storage_group_name: name of the storage group
-        :param action: the migration action e.g. Cutover, Sync, Commit, Recover, ReadyTgt
-        :param options: a dict of possible options - depends on action type, example
-        options={'cutover': {'force': True}}
+        :param action: the migration action e.g. Cutover, Sync, Commit,
+                       Recover, ReadyTgt
+        :param options: a dict of possible options - depends on action type.
+                        example options={'cutover': {'force': True}}
         :param _async: flag to indicate if call should be async
         """
         payload = {'action': action}
@@ -155,11 +173,14 @@ class MigrationFunctions(object):
         if _async:
             payload.update(ASYNC_UPDATE)
         return self.modify_resource(
-            self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name, payload=payload)
+            self.array_id, MIGRATION, 'storagegroup',
+            resource_name=storage_group_name, payload=payload)
 
     def delete_storage_group_migration(self, storage_group_name):
         """Given a name, delete the storage group migration session.
 
         :param storage_group_name: the name of the migrating storage group
         """
-        self.delete_resource(self.array_id, MIGRATION, 'storagegroup', resource_name=storage_group_name)
+        self.delete_resource(
+            self.array_id, MIGRATION, 'storagegroup',
+            resource_name=storage_group_name)

--- a/PyU4V/migration.py
+++ b/PyU4V/migration.py
@@ -1,5 +1,5 @@
 # The MIT License (MIT)
-# Copyright (c) 2016 Dell Inc. or its subsidiaries.
+# Copyright (c) 2019 Dell Inc. or its subsidiaries.
 
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -47,7 +47,7 @@ class MigrationFunctions(object):
     def get_migration_info(self):
         """Return migration information for an array.
 
-        :return: dict
+        :returns: dict
         """
         target_uri = '/{}/migration/symmetrix/{}'.format(
             self.U4V_VERSION, self.array_id)
@@ -56,7 +56,7 @@ class MigrationFunctions(object):
     def get_array_migration_capabilities(self):
         """Check what migration facilities are available.
 
-        :return: array_capabilities dict
+        :returns: array_capabilities dict
         """
         array_capabilities = {}
         target_uri = ("/{}/migration/capabilities/symmetrix".format(
@@ -75,7 +75,7 @@ class MigrationFunctions(object):
     def get_environment_list(self):
         """Get list of all environments.
 
-        :return: list of all environments
+        :returns: list of all environments
         """
         response = self.get_resource(self.array_id, MIGRATION, 'environment')
         environment_list = response.get('arrayId', []) if response else []
@@ -105,7 +105,7 @@ class MigrationFunctions(object):
         """Get list of all storage groups.
 
         :param include_migrations: return only SGs with migration sessions
-        :return: list of storage groups or migrating storage groups
+        :returns: list of storage groups or migrating storage groups
         """
         filters = {}
         if include_migrations:
@@ -139,7 +139,7 @@ class MigrationFunctions(object):
         :param no_compression: boolean, whether or not to use compression
         :param pre_copy: boolean, whether or not to pre copy
         :param validate: boolean, whether or not to validate
-        :return: the new storage group dict
+        :returns: the new storage group dict
         """
         payload = {"otherArrayId": target_array_id}
         if srp_id:

--- a/PyU4V/univmax_conn.py
+++ b/PyU4V/univmax_conn.py
@@ -27,6 +27,7 @@ from PyU4V.common import CommonFunctions
 from PyU4V.performance import PerformanceFunctions
 from PyU4V.provisioning import ProvisioningFunctions
 from PyU4V.replication import ReplicationFunctions
+from PyU4V.migration import MigrationFunctions
 from PyU4V.rest_requests import RestRequests
 from PyU4V.utils import config_handler
 from PyU4V.utils import constants
@@ -86,6 +87,8 @@ class U4VConn(object):
         self.replication = ReplicationFunctions(
             self.array_id, self.request, self.common,
             self.provisioning, self.U4V_VERSION)
+        self.migration = MigrationFunctions(
+            self.array_id, self.request, self.common, self.U4V_VERSION)
 
     def close_session(self):
         """Close the current rest session."""
@@ -107,3 +110,4 @@ class U4VConn(object):
         self.performance.array_id = array_id
         self.provisioning.array_id = array_id
         self.replication.array_id = array_id
+        self.migration.array_id = array_id

--- a/PyU4V/univmax_conn.py
+++ b/PyU4V/univmax_conn.py
@@ -24,10 +24,10 @@ import logging
 import time
 
 from PyU4V.common import CommonFunctions
+from PyU4V.migration import MigrationFunctions
 from PyU4V.performance import PerformanceFunctions
 from PyU4V.provisioning import ProvisioningFunctions
 from PyU4V.replication import ReplicationFunctions
-from PyU4V.migration import MigrationFunctions
 from PyU4V.rest_requests import RestRequests
 from PyU4V.utils import config_handler
 from PyU4V.utils import constants

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -629,7 +629,8 @@ class FakeRequestsSession(object):
         if 'storagegroup' in url:
             return_object = self._migration_sg(url)
         elif 'environment' in url:
-            if "/environment/" + self.data.migration_environment_list["arrayId"][0] in url:
+            env_name = self.data.migration_environment_list["arrayId"][0]
+            if "/environment/" + env_name in url:
                 return_object = self.data.migration_environment_details
             else:
                 return_object = self.data.migration_environment_list
@@ -2177,6 +2178,7 @@ class PyU4VReplicationTest(testtools.TestCase):
 
 
 class PyU4VMigrationTest(testtools.TestCase):
+    """Test migration."""
 
     def setUp(self):
         """Setup."""
@@ -2191,57 +2193,71 @@ class PyU4VMigrationTest(testtools.TestCase):
         self.migration = self.conn.migration
 
     def test_get_migration_info(self):
-        """Test get_migration_info"""
+        """Test get_migration_info."""
         migration_info = self.migration.get_migration_info()
         self.assertEqual(self.data.migration_info, migration_info)
 
     def test_get_array_migration_capabilities(self):
-        """Test get_array_migration_capabilities"""
+        """Test get_array_migration_capabilities."""
         capabilities = self.migration.get_array_migration_capabilities()
-        self.assertEqual(self.data.migration_capabilities['storageArrayCapability'][0], capabilities)
+        capabilities_ref = \
+            self.data.migration_capabilities['storageArrayCapability'][0]
+        self.assertEqual(capabilities_ref, capabilities)
 
     def test_get_environment_list(self):
-        """Test get_environment_list"""
+        """Test get_environment_list."""
         environment_list = self.migration.get_environment_list()
-        self.assertEqual(self.data.migration_environment_list["arrayId"], environment_list)
+        env_list_ref = self.data.migration_environment_list["arrayId"]
+        self.assertEqual(env_list_ref, environment_list)
 
     def test_get_environment(self):
-        """Test get_environment"""
-        environment_details = self.migration.get_environment(self.data.migration_environment_list["arrayId"][0])
-        self.assertEqual(self.data.migration_environment_details, environment_details)
+        """Test get_environment."""
+        env_name = self.data.migration_environment_list["arrayId"][0]
+        environment_details = self.migration.get_environment(env_name)
+        env_details_ref = self.data.migration_environment_details
+        self.assertEqual(env_details_ref, environment_details)
 
     def test_delete_environment(self):
-        """Test delete_environment"""
-        with mock.patch.object(self.migration, 'delete_resource') as mock_delete:
-            self.migration.delete_environment(self.data.migration_environment_list["arrayId"][0])
+        """Test delete_environment."""
+        with mock.patch.object(self.migration, 'delete_resource') \
+                as mock_delete:
+            env_name = self.data.migration_environment_list["arrayId"][0]
+            self.migration.delete_environment(env_name)
             mock_delete.assert_called_once()
 
     def test_get_storage_group_list(self):
-        """Test get_storage_group_list"""
+        """Test get_storage_group_list."""
         storage_group_list = self.migration.get_storage_group_list()
-        self.assertEqual(self.data.sg_list_migration['name'], storage_group_list)
+        sg_list_ref = self.data.sg_list_migration['name']
+        self.assertEqual(sg_list_ref, storage_group_list)
 
     def test_get_storage_group(self):
-        """Test get_storage_group"""
-        storage_group = self.migration.get_storage_group(self.data.sg_list_migration["name"][0])
+        """Test get_storage_group."""
+        sg_name_ref = self.data.sg_list_migration['name'][0]
+        storage_group = self.migration.get_storage_group(sg_name_ref)
         self.assertEqual(self.data.sg_details_migration[0], storage_group)
 
     def test_create_storage_group_migration(self):
-        """Test create_storage_group_migration"""
-        with mock.patch.object(self.migration, 'create_resource') as mock_create:
-            self.migration.create_storage_group_migration(self.data.storagegroup_name, self.data.remote_array)
+        """Test create_storage_group_migration."""
+        with mock.patch.object(self.migration, 'create_resource') \
+                as mock_create:
+            self.migration.create_storage_group_migration(
+                self.data.storagegroup_name, self.data.remote_array)
             self.assertEqual(1, mock_create.call_count)
 
     def test_modify_storage_group_migration(self):
-        """Test modify_storage_group_migration"""
+        """Test modify_storage_group_migration."""
         with mock.patch.object(self.migration, 'modify_resource') as mock_mod:
-            self.migration.modify_storage_group_migration(self.data.storagegroup_name, 'Recover')
+            self.migration.modify_storage_group_migration(
+                self.data.storagegroup_name, 'Recover')
             mock_mod.assert_called_once()
 
     def test_delete_storage_group_migration(self):
-        """Test delete_storage_group_migration"""
-        with mock.patch.object(self.migration, 'delete_resource') as mock_delete:
-            self.migration.delete_storage_group_migration(self.data.storagegroup_name)
+        """Test delete_storage_group_migration."""
+        with mock.patch.object(self.migration, 'delete_resource') \
+                as mock_delete:
+            self.migration.delete_storage_group_migration(
+                self.data.storagegroup_name)
             mock_delete.assert_called_once()
 
 

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -210,6 +210,23 @@ class CommonData(object):
                        "symmetrixId": array,
                        "numSnapVXSnapshots": 1}]
 
+    sg_details_migration = [{"targetArray": remote_array,
+                             "sourceArray": array,
+                             "totalCapacity": 8.0,
+                             "targetMaskingView": [masking_view_name_f],
+                             "state": "Synchronized",
+                             "sourceMaskingView": [masking_view_name_i],
+                             "remainingCapacity": 0.0,
+                             "devicePairs": [{
+                                 "invalidSrc": False,
+                                 "srcVolumeName": 'my-vol',
+                                 "invalidTgt": False,
+                                 "tgtVolumeName": 'my-vol2',
+                                 "missingSrc": False,
+                                 "missingTgt": False
+                             }],
+                             "storageGroup": storagegroup_name}]
+
     sg_rdf_details = [{"storageGroupName": storagegroup_name,
                        "symmetrixId": array,
                        "modes": ["Synchronous"],
@@ -222,6 +239,8 @@ class CommonData(object):
 
     sg_list_rep = {"name": [storagegroup_name]}
     sg_rdf_list = {"rdfgs": [rdf_group_no]}
+
+    sg_list_migration = {"name": [storagegroup_name]}
 
     srp_details = {"srpSloDemandId": ["Bronze", "Diamond", "Gold",
                                       "None", "Optimized", "Silver"],
@@ -331,6 +350,25 @@ class CommonData(object):
 
     rep_info = {"symmetrixId": array, "storageGroupCount": 1486,
                 "replicationCacheUsage": 0, "rdfGroupCount": 7}
+
+    # migration
+    migration_info = {"symmetrixId": array, "storageGroupCount": 1486,
+                      "local": True, "migrationSessionCount": 10}
+    migration_capabilities = {"storageArrayCapability": [
+        {
+            "srdfsTarget": True,
+            "dmSource": True,
+            "srdfsSource": True,
+            "dmTarget": True,
+            "compression": True,
+            "arrayId": array
+        }
+    ]}
+    migration_environment_list = {"arrayId": [array]}
+    migration_environment_details = {"symmetrixId": array,
+                                     "otherSymmetrixId": remote_array,
+                                     "invalid": False,
+                                     "state": "OK"}
 
     # system
     job_list = [{"status": "SUCCEEDED",
@@ -443,6 +481,9 @@ class FakeRequestsSession(object):
 
         elif 'replication' in url:
             return_object = self._replication(url)
+
+        elif 'migration' in url:
+            return_object = self._migration(url)
 
         elif 'system' in url:
             return_object = self._system(url)
@@ -581,6 +622,25 @@ class FakeRequestsSession(object):
                         break
         elif self.data.storagegroup_name in url:
             return_object = self.data.sg_details_rep[0]
+        return return_object
+
+    def _migration(self, url):
+        return_object = self.data.migration_info
+        if 'storagegroup' in url:
+            return_object = self._migration_sg(url)
+        elif 'environment' in url:
+            if "/environment/" + self.data.migration_environment_list["arrayId"][0] in url:
+                return_object = self.data.migration_environment_details
+            else:
+                return_object = self.data.migration_environment_list
+        elif 'capabilities' in url:
+            return_object = self.data.migration_capabilities
+        return return_object
+
+    def _migration_sg(self, url):
+        return_object = self.data.sg_list_migration
+        if self.data.sg_list_migration['name'][0] in url:
+            return_object = self.data.sg_details_migration[0]
         return return_object
 
     def _system(self, url):
@@ -2113,6 +2173,75 @@ class PyU4VReplicationTest(testtools.TestCase):
                 self.replication, 'delete_resource') as mock_delete:
             self.replication.delete_storagegroup_srdf(
                 self.data.storagegroup_name, self.data.rdf_group_no)
+            mock_delete.assert_called_once()
+
+
+class PyU4VMigrationTest(testtools.TestCase):
+
+    def setUp(self):
+        """Setup."""
+        super(PyU4VMigrationTest, self).setUp()
+        self.data = CommonData()
+        rest_requests.RestRequests.establish_rest_session = mock.Mock(
+            return_value=FakeRequestsSession())
+        config_file = FakeConfigFile.create_fake_config_file()
+        univmax_conn.file_path = config_file
+        self.conn = univmax_conn.U4VConn(array_id=self.data.array)
+        self.common = self.conn.common
+        self.migration = self.conn.migration
+
+    def test_get_migration_info(self):
+        """Test get_migration_info"""
+        migration_info = self.migration.get_migration_info()
+        self.assertEqual(self.data.migration_info, migration_info)
+
+    def test_get_array_migration_capabilities(self):
+        """Test get_array_migration_capabilities"""
+        capabilities = self.migration.get_array_migration_capabilities()
+        self.assertEqual(self.data.migration_capabilities['storageArrayCapability'][0], capabilities)
+
+    def test_get_environment_list(self):
+        """Test get_environment_list"""
+        environment_list = self.migration.get_environment_list()
+        self.assertEqual(self.data.migration_environment_list["arrayId"], environment_list)
+
+    def test_get_environment(self):
+        """Test get_environment"""
+        environment_details = self.migration.get_environment(self.data.migration_environment_list["arrayId"][0])
+        self.assertEqual(self.data.migration_environment_details, environment_details)
+
+    def test_delete_environment(self):
+        """Test delete_environment"""
+        with mock.patch.object(self.migration, 'delete_resource') as mock_delete:
+            self.migration.delete_environment(self.data.migration_environment_list["arrayId"][0])
+            mock_delete.assert_called_once()
+
+    def test_get_storage_group_list(self):
+        """Test get_storage_group_list"""
+        storage_group_list = self.migration.get_storage_group_list()
+        self.assertEqual(self.data.sg_list_migration['name'], storage_group_list)
+
+    def test_get_storage_group(self):
+        """Test get_storage_group"""
+        storage_group = self.migration.get_storage_group(self.data.sg_list_migration["name"][0])
+        self.assertEqual(self.data.sg_details_migration[0], storage_group)
+
+    def test_create_storage_group_migration(self):
+        """Test create_storage_group_migration"""
+        with mock.patch.object(self.migration, 'create_resource') as mock_create:
+            self.migration.create_storage_group_migration(self.data.storagegroup_name, self.data.remote_array)
+            self.assertEqual(1, mock_create.call_count)
+
+    def test_modify_storage_group_migration(self):
+        """Test modify_storage_group_migration"""
+        with mock.patch.object(self.migration, 'modify_resource') as mock_mod:
+            self.migration.modify_storage_group_migration(self.data.storagegroup_name, 'Recover')
+            mock_mod.assert_called_once()
+
+    def test_delete_storage_group_migration(self):
+        """Test delete_storage_group_migration"""
+        with mock.patch.object(self.migration, 'delete_resource') as mock_delete:
+            self.migration.delete_storage_group_migration(self.data.storagegroup_name)
             mock_delete.assert_called_once()
 
 

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -2219,8 +2219,8 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_delete_environment(self):
         """Test delete_environment."""
-        with mock.patch.object(self.migration,
-                               'delete_resource') as mock_delete:
+        with mock.patch.object(
+                self.migration, 'delete_resource') as mock_delete:
             env_name = self.data.migration_environment_list["arrayId"][0]
             self.migration.delete_environment(env_name)
             mock_delete.assert_called_once()
@@ -2239,8 +2239,8 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_create_storage_group_migration(self):
         """Test create_storage_group_migration."""
-        with mock.patch.object(self.migration,
-                               'create_resource') as mock_create:
+        with mock.patch.object(
+                self.migration, 'create_resource') as mock_create:
             self.migration.create_storage_group_migration(
                 self.data.storagegroup_name, self.data.remote_array)
             self.assertEqual(1, mock_create.call_count)
@@ -2254,8 +2254,8 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_delete_storage_group_migration(self):
         """Test delete_storage_group_migration."""
-        with mock.patch.object(self.migration,
-                                'delete_resource') as mock_delete:
+        with mock.patch.object(
+                self.migration, 'delete_resource') as mock_delete:
             self.migration.delete_storage_group_migration(
                 self.data.storagegroup_name)
             mock_delete.assert_called_once()

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -2219,7 +2219,7 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_delete_environment(self):
         """Test delete_environment."""
-        with mock.patch.object(self.migration, 
+        with mock.patch.object(self.migration,
                                'delete_resource') as mock_delete:
             env_name = self.data.migration_environment_list["arrayId"][0]
             self.migration.delete_environment(env_name)
@@ -2239,7 +2239,7 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_create_storage_group_migration(self):
         """Test create_storage_group_migration."""
-        with mock.patch.object(self.migration, 
+        with mock.patch.object(self.migration,
                                'create_resource') as mock_create:
             self.migration.create_storage_group_migration(
                 self.data.storagegroup_name, self.data.remote_array)
@@ -2254,7 +2254,7 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_delete_storage_group_migration(self):
         """Test delete_storage_group_migration."""
-        with mock.patch.object(self.migration, 
+        with mock.patch.object(self.migration,
                                 'delete_resource') as mock_delete:
             self.migration.delete_storage_group_migration(
                 self.data.storagegroup_name)

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -2200,8 +2200,8 @@ class PyU4VMigrationTest(testtools.TestCase):
     def test_get_array_migration_capabilities(self):
         """Test get_array_migration_capabilities."""
         capabilities = self.migration.get_array_migration_capabilities()
-        capabilities_ref = \
-            self.data.migration_capabilities['storageArrayCapability'][0]
+        capabilities_ref = (
+            self.data.migration_capabilities['storageArrayCapability'][0])
         self.assertEqual(capabilities_ref, capabilities)
 
     def test_get_environment_list(self):
@@ -2219,8 +2219,8 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_delete_environment(self):
         """Test delete_environment."""
-        with mock.patch.object(self.migration, 'delete_resource') \
-                as mock_delete:
+        with mock.patch.object(self.migration, 
+                               'delete_resource') as mock_delete:
             env_name = self.data.migration_environment_list["arrayId"][0]
             self.migration.delete_environment(env_name)
             mock_delete.assert_called_once()
@@ -2239,8 +2239,8 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_create_storage_group_migration(self):
         """Test create_storage_group_migration."""
-        with mock.patch.object(self.migration, 'create_resource') \
-                as mock_create:
+        with mock.patch.object(self.migration, 
+                               'create_resource') as mock_create:
             self.migration.create_storage_group_migration(
                 self.data.storagegroup_name, self.data.remote_array)
             self.assertEqual(1, mock_create.call_count)
@@ -2254,8 +2254,8 @@ class PyU4VMigrationTest(testtools.TestCase):
 
     def test_delete_storage_group_migration(self):
         """Test delete_storage_group_migration."""
-        with mock.patch.object(self.migration, 'delete_resource') \
-                as mock_delete:
+        with mock.patch.object(self.migration, 
+                                'delete_resource') as mock_delete:
             self.migration.delete_storage_group_migration(
                 self.data.storagegroup_name)
             mock_delete.assert_called_once()


### PR DESCRIPTION
Added methods for managing nondisruptive migrations. These methods are written in migration.py and correspond to the endpoints https://[ip]:[port]/univmax/restapi/[version]/migration/[etc]. The changes made are the addition of migration.py, the alteration of univmax_conn.py to incorporate migration.py, and the addition of test coverage for migration in test_pyu4v.py.