### PR TITLE
31/logger-fix

### DIFF
--- a/PyU4V.conf.example
+++ b/PyU4V.conf.example
@@ -14,7 +14,7 @@ verify=/path-to-file/server_hostname.pem
 keys=root,PyU4V
 
 [handlers]
-keys=consoleHandler
+keys=consoleHandler, fileHandler
 
 [formatters]
 keys=simpleFormatter

--- a/PyU4V.conf.example
+++ b/PyU4V.conf.example
@@ -36,10 +36,10 @@ formatter=simpleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
-class=FileHandler
+class=handlers.RotatingFileHandler
 level=INFO
 formatter=simpleFormatter
-args=(~/.PyU4V/PyU4V.log)
+args=('~/.PyU4V/PyU4V.log', 'a')
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/PyU4V/__init__.py
+++ b/PyU4V/__init__.py
@@ -8,7 +8,7 @@
 
 from .univmax_conn import U4VConn  # noqa: F401
 __title__ = 'pyu4v'
-__version__ = '3.1.3'
+__version__ = '3.1.4'
 __author__ = 'Dell EMC or its subsidiaries'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2019 Dell EMC Inc'

--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,11 @@ eg: https://10.0.0.1:8443/univmax/restapi/docs.
 
 VERSION 3
 
-Please note that version '3.1.3' of the library is NOT BACKWARDS
+Please note that version '3.1.4' of the library is NOT BACKWARDS
 COMPATIBLE with scripts written with version 2.x of PyU4V, and does not
 support any Unisphere for VMAX version earlier than 8.4 - PyU4V version 2.0.2.6 is
 still available on Pip, and there is a 'stable/2.0' branch available on Github.
-Version 3.1.1 is now limited to security and bug fixes only. Features and
+Version 3.1.x is now limited to security and bug fixes only. Features and
 enhancements from the community will be accepted after the next major PyU4V
 release.
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 from setuptools import setup
 
 setup(name='PyU4V',
-      version='3.1.3',
+      version='3.1.4',
       url='https://github.com/MichaelMcAleer/PyU4V/',
       author='Dell Inc. or its subsidiaries',
       author_email='Michael.Mcaleer@dell.com',


### PR DESCRIPTION
When FileHandler is loaded by logging.fileConfig() it is throwing an exception which results in NullHandler always being set. This fix changes the .conf setting in section [handler_filehandler] from class=FileHandler to class=handlers.RotatingFileHandler and sets the 'add' flag to the args.