### PR TITLE
Config & Logger Handling Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,126 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+.stestr/
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in
+#   version control. However, in case of collaboration, if having platform-
+#   specific dependencies or dependencies having no cross-platform support,
+#   pipenv may install dependencies that don't work, or not install all needed
+#   dependencies.
+Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/PyU4V.conf.example
+++ b/PyU4V.conf.example
@@ -36,10 +36,10 @@ formatter=simpleFormatter
 args=(sys.stdout,)
 
 [handler_fileHandler]
-class=FileHandler
+class=handlers.RotatingFileHandler
 level=INFO
 formatter=simpleFormatter
-args=(~/.PyU4V/PyU4V.log)
+args=(PyU4V.log, 'a')
 
 [formatter_simpleFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/PyU4V/__init__.py
+++ b/PyU4V/__init__.py
@@ -8,7 +8,7 @@
 
 from .univmax_conn import U4VConn  # noqa: F401
 __title__ = 'pyu4v'
-__version__ = '3.1.3'
+__version__ = '3.1.4'
 __author__ = 'Dell EMC or its subsidiaries'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2019 Dell EMC Inc'

--- a/PyU4V/utils/config_handler.py
+++ b/PyU4V/utils/config_handler.py
@@ -41,7 +41,8 @@ def set_logger_and_config(file_path=None):
     elif os.path.isfile(conf_file_name):
         conf_file = conf_file_name
     else:
-        global_path = os.path.normpath('~/.PyU4V/PyU4V.conf')
+        global_path = os.path.normpath('{home_path}/.PyU4V/PyU4V.conf'.format(
+            home_path=os.path.expanduser('~')))
         if os.path.isfile(global_path):
             conf_file = global_path
     if conf_file is not None:

--- a/PyU4V/utils/exception.py
+++ b/PyU4V/utils/exception.py
@@ -105,3 +105,10 @@ class UnauthorizedRequestException(PyU4VException):
     """UnauthorizedRequestException."""
 
     meesage = 'Unauthorized request - please check credentials'
+
+
+class MissingConfigurationException(PyU4VException):
+    """MissingConfigurationFileException"""
+
+    message = ('PyU4V settings not be loaded, please check file location or '
+               'univmax_conn input parameters.')

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ eg: https://10.0.0.1:8443/univmax/restapi/docs.
 
 VERSION 3
 
-Please note that version '3.1.3' of the library is NOT BACKWARDS
+Please note that version '3.1.4' of the library is NOT BACKWARDS
 COMPATIBLE with scripts written with version 2.x of PyU4V, and does not
 support any Unisphere for VMAX version earlier than 8.4 - PyU4V version 2.0.2.6 is
 still available on Pip, and there is a 'stable/2.0' branch available on Github.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 from setuptools import setup
 
 setup(name='PyU4V',
-      version='3.1.3',
+      version='3.1.4',
       url='https://github.com/MichaelMcAleer/PyU4V/',
       author='Dell Inc. or its subsidiaries',
       author_email='Michael.Mcaleer@dell.com',


### PR DESCRIPTION
A number of improvements have been included in this pull request:
- Configuration file loading from `~/.PyU4V` in windows has been fixed
- If user does not set env config when instantiating `U4VConn()` or does not create a `PyU4V.conf` and set file path, place in working directory, or in `~/.PyU4V`, a `MissingConfigurationException `will be raised
- Logger now initialises on Windows correctly, will place log file in working directory unless otherwise set in `PyU4V.conf`
- `.gitignore` has been added

All tests are running cleanly across py2.7/3.x/pep8/pylint