### PR TITLE
Header Typo

### DIFF
--- a/PyU4V/__init__.py
+++ b/PyU4V/__init__.py
@@ -8,7 +8,7 @@
 
 from .univmax_conn import U4VConn  # noqa: F401
 __title__ = 'pyu4v'
-__version__ = '3.1.4'
+__version__ = '3.1.5'
 __author__ = 'Dell EMC or its subsidiaries'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2019 Dell EMC Inc'

--- a/PyU4V/rest_requests.py
+++ b/PyU4V/rest_requests.py
@@ -48,7 +48,7 @@ class RestRequests(object):
         self.base_url = base_url
         self.headers = {'content-type': 'application/json',
                         'accept': 'application/json',
-                        'application_type': application_type}
+                        'application-type': application_type}
         self.timeout = 120
         self.session = self.establish_rest_session()
 

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ eg: https://10.0.0.1:8443/univmax/restapi/docs.
 
 VERSION 3
 
-Please note that version '3.1.4' of the library is NOT BACKWARDS
+Please note that version '3.1.5' of the library is NOT BACKWARDS
 COMPATIBLE with scripts written with version 2.x of PyU4V, and does not
 support any Unisphere for VMAX version earlier than 8.4 - PyU4V version 2.0.2.6 is
 still available on Pip, and there is a 'stable/2.0' branch available on Github.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@
 from setuptools import setup
 
 setup(name='PyU4V',
-      version='3.1.4',
+      version='3.1.5',
       url='https://github.com/MichaelMcAleer/PyU4V/',
       author='Dell Inc. or its subsidiaries',
       author_email='Michael.Mcaleer@dell.com',

--- a/tests/test_pyu4v.py
+++ b/tests/test_pyu4v.py
@@ -501,6 +501,15 @@ class FakeRequestsSession(object):
 
         return status_code, return_object
 
+    def _establish_rest_session(self):
+        ref_headers = {'content-type': 'application/json',
+                       'accept': 'application/json',
+                       'application-type': 'pyu4v'}
+        self.assertEqual(ref_headers, self.rest.session.headers)
+        self.assertEqual('smc', self.rest.session.auth.username)
+        self.assertEqual('smc', self.rest.session.auth.password)
+        self.assertEqual(False, self.rest.session.verify)
+
     def _sloprovisioning_volume(self, url, params):
         return_object = self.data.volume_list[2]
         if params:


### PR DESCRIPTION
fix for typo in header application_type should have been application-type.  Header is ignored if incorrect.  Incremented version to 3.1.5