### PR TITLE
92/Docs API Glossary Cleanup

### DIFF
--- a/docs/source/PyU4V.rst
+++ b/docs/source/PyU4V.rst
@@ -106,15 +106,3 @@ PyU4V\.utils
     :members:
     :undoc-members:
     :show-inheritance:
-
-PyU4V\.tools
-------------
-
-.. toctree::
-
-    PyU4V.tools
-
-.. automodule:: PyU4V.tools
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/PyU4V.tools.rst
+++ b/docs/source/PyU4V.tools.rst
@@ -1,7 +1,0 @@
-PyU4V\.tools\.openstack\.migrate\_utils
----------------------------------------
-
-.. automodule:: PyU4V.tools.openstack.migrate_utils
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/source/PyU4V.utils.rst
+++ b/docs/source/PyU4V.utils.rst
@@ -46,22 +46,6 @@ PyU4V\.utils\.file\_handler
     :undoc-members:
     :show-inheritance:
 
-PyU4V\.utils\.performance\_category\_map
-----------------------------------------
-
-.. automodule:: PyU4V.utils.performance_category_map
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-PyU4V\.utils\.performance\_constants
-------------------------------------
-
-.. automodule:: PyU4V.utils.performance_constants
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 PyU4V\.utils\.time\_handler
 ---------------------------
 


### PR DESCRIPTION
Two files in utils, `performance_constants.py` and `performance_category_map.py`, were mistakenly added to the `toctree` for the API glossary. These have been removed in this pull request.

In addition `migrate_utils.py` has also been removed from the API glossary, a guide on its usage is available for users in the 'Tools Guide' section of our documentation, available here: https://pyu4v.readthedocs.io/en/latest/tools.html#openstack
