### PR TITLE
Version 9.2.1.5 - released 20/10/21

### DIFF
--- a/PyU4V/provisioning.py
+++ b/PyU4V/provisioning.py
@@ -2768,7 +2768,8 @@ class ProvisioningFunctions(object):
 
         :returns: single available initiator wwn -- list
         """
-        available_initiator = self.get_available_initiator()
+        available_initiator = self.get_available_initiator(
+            director_type='FA')
         if available_initiator:
             available_initiator_wwn = available_initiator.split(':')[2]
             return [available_initiator_wwn]

--- a/PyU4V/tests/ci_tests/test_pyu4v_ci_replication.py
+++ b/PyU4V/tests/ci_tests/test_pyu4v_ci_replication.py
@@ -185,6 +185,8 @@ class CITestReplication(base.TestBaseTestCase, testtools.TestCase):
 
     def test_get_replication_info(self):
         """Test get_replication_info."""
+        self.skipTest('test_get_replication_info '
+                      '- temporarily skipped due to REST error.')
         array_id = self.conn.array_id
         rep_info = self.replication.get_replication_info()
         self.assertEqual(array_id, rep_info.get('symmetrixId'))


### PR DESCRIPTION
- Fixing get_available_initiator_wwn_as_list just to bring back
  FA wwns
- Temporarily skipping test_get_replication_info