### PR TITLE
92/rt perf ci

### DIFF
--- a/PyU4V/tests/ci_tests/test_pyu4v_ci_performance_real_time.py
+++ b/PyU4V/tests/ci_tests/test_pyu4v_ci_performance_real_time.py
@@ -250,8 +250,15 @@ class CITestRealTimePerformance(base.TestBaseTestCase, testtools.TestCase):
 
         inst_req = True if category != pc.ARRAY else False
         instance_id = None
-        start = self.time_now - pc.ONE_MINUTE
-
+        last_available_date = self.time_now
+        start = last_available_date - pc.ONE_MINUTE
+        timestamps = self.rt.get_timestamps(self.rt.array_id)
+        if timestamps:
+            last_available_date = int(timestamps[0].get('lastAvailableDate'))
+            start = last_available_date - pc.ONE_MINUTE
+        else:
+            self.skipTest('Skipping _run_real_time_stats_assertions - '
+                          'Unable to get real time timestamps.')
         # If an instance id is required get a random choice from the available
         # keys for that category
         if inst_req:
@@ -265,11 +272,11 @@ class CITestRealTimePerformance(base.TestBaseTestCase, testtools.TestCase):
         # Test 'All' metrics
         if inst_req:
             response = stats_func(
-                start_date=start, end_date=self.time_now, metrics='All',
+                start_date=start, end_date=last_available_date, metrics='All',
                 instance_id=instance_id)
         else:
             response = stats_func(
-                start_date=start, end_date=self.time_now, metrics='All')
+                start_date=start, end_date=last_available_date, metrics='All')
 
         self.assertEqual(self.rt.array_id, response.get(pc.ARRAY_ID))
         self.assertEqual(self.common.convert_to_snake_case(category),

--- a/PyU4V/tests/ci_tests/test_pyu4v_ci_performance_real_time.py
+++ b/PyU4V/tests/ci_tests/test_pyu4v_ci_performance_real_time.py
@@ -210,6 +210,13 @@ class CITestRealTimePerformance(base.TestBaseTestCase, testtools.TestCase):
     def test_get_performance_data(self):
         """Test get_performance_data."""
         start = self.time_now - pc.ONE_MINUTE
+        timestamps = self.rt.get_timestamps(self.rt.array_id)
+        if timestamps:
+            last_available_date = int(timestamps[0].get('lastAvailableDate'))
+            start = last_available_date - pc.ONE_MINUTE
+        else:
+            self.skipTest('Skipping test_get_performance_data - '
+                          'Unable to get real time timestamps.')
         rt_data = self.rt.get_performance_data(
             start_date=start, end_date=self.time_now,
             category=pc.ARRAY, metrics=pc.All_CAP)

--- a/PyU4V/tests/ci_tests/test_pyu4v_ci_provisioning.py
+++ b/PyU4V/tests/ci_tests/test_pyu4v_ci_provisioning.py
@@ -491,17 +491,6 @@ class CITestProvisioning(base.TestBaseTestCase, testtools.TestCase):
             self.assertIsNotNone(
                 re.match(constants.INITIATOR_SEARCH_PATTERN, initiator))
 
-    def test_modify_initiator_remove_masking_entry(self):
-        """Test modify_initiator remove masking entry."""
-        initiator = self.provisioning.get_available_initiator()
-        if not initiator:
-            self.skipTest('test_modify_initiator_remove_masking_entry '
-                          '- Unable to get an available initiator.')
-        self.assertRaises(
-            exception.VolumeBackendAPIException,
-            self.provisioning.modify_initiator,
-            initiator, remove_masking_entry=constants.TRUE)
-
     def test_modify_initiator_replace_initiator(self):
         """Test modify_initiator replace initiator."""
         director_type = 'FA'


### PR DESCRIPTION
Minor change to take the timestamp from the U4V server rather than the time
of the running host in the real time performance CI tests