### PR TITLE
Add emulation_type parameter to storage group and volume creation function

### DIFF
--- a/PyU4V/provisioning.py
+++ b/PyU4V/provisioning.py
@@ -2811,7 +2811,7 @@ class ProvisioningFunctions(object):
         :returns: split ids -- list
         """
         split_id_list = list()
-        response = self.conn.common.get_resource(category=SLOPROVISIONING,
+        response = self.common.get_resource(category=SLOPROVISIONING,
                                                  resource_level=SYMMETRIX,
                                                  resource_level_id=self.array_id,
                                                  resource_type=FICON_SPLIT)
@@ -2825,7 +2825,7 @@ class ProvisioningFunctions(object):
         :param split_id: split id -- str
         :returns: split details -- dict
         """
-        return self.conn.common.get_resource(category=SLOPROVISIONING,
+        return self.common.get_resource(category=SLOPROVISIONING,
                                              resource_level=SYMMETRIX,
                                              resource_level_id=self.array_id,
                                              resource_type=FICON_SPLIT,
@@ -2838,7 +2838,7 @@ class ProvisioningFunctions(object):
         :returns: CU Image ssids -- list
         """
         cu_image_ssid_list = list()
-        response = self.conn.common.get_resource(category=SLOPROVISIONING,
+        response = self.common.get_resource(category=SLOPROVISIONING,
                                                  resource_level=SYMMETRIX,
                                                  resource_level_id=self.array_id,
                                                  resource_type=FICON_SPLIT,
@@ -2855,7 +2855,7 @@ class ProvisioningFunctions(object):
         :param cu_ssid: cu image ssid -- str
         :returns: CU Image details -- dict
         """
-        return self.conn.common.get_resource(category=SLOPROVISIONING,
+        return self.common.get_resource(category=SLOPROVISIONING,
                                              resource_level=SYMMETRIX,
                                              resource_level_id=self.array_id,
                                              resource_type=FICON_SPLIT,
@@ -2886,14 +2886,14 @@ class ProvisioningFunctions(object):
         # FIXME This call takes over 5 minutes on my powermax 8000 - so need to force async call
         new_cu_data.update(ASYNC_UPDATE)
 
-        create_cu_async_job = (self.conn.common.create_resource(category=SLOPROVISIONING,
+        create_cu_async_job = (self.common.create_resource(category=SLOPROVISIONING,
                                                                 resource_level=SYMMETRIX,
                                                                 resource_level_id=self.array_id,
                                                                 resource_type=FICON_SPLIT,
                                                                 resource_type_id=split_id,
                                                                 resource=CU_IMAGE,
                                                                 payload=new_cu_data))
-        return self.conn.common.wait_for_job(
+        return self.common.wait_for_job(
             operation='Create CU Image with volume', status_code=constants.STATUS_202,
             job=create_cu_async_job)
 
@@ -2905,7 +2905,7 @@ class ProvisioningFunctions(object):
         :returns: Volume ids -- list
         """
         volume_id_list = list()
-        response = self.conn.common.get_resource(category=SLOPROVISIONING,
+        response = self.common.get_resource(category=SLOPROVISIONING,
                                                  resource_level=SYMMETRIX,
                                                  resource_level_id=self.array_id,
                                                  resource_type=FICON_SPLIT,
@@ -2925,7 +2925,7 @@ class ProvisioningFunctions(object):
         :pamam vol_id volume device id to be mapped to the cu -- str
         :returns: volume details -- dict
         """
-        return self.conn.common.get_resource(category=SLOPROVISIONING,
+        return self.common.get_resource(category=SLOPROVISIONING,
                                              resource_level=SYMMETRIX,
                                              resource_level_id=self.array_id,
                                              resource_type=FICON_SPLIT,
@@ -2992,7 +2992,7 @@ class ProvisioningFunctions(object):
         # FIXME This call takes over 5 minutes on my powermax 8000 - so need to force async call
         edit_cu_data.update(ASYNC_UPDATE)
 
-        edit_cu_async_job = (self.conn.common.modify_resource(category=SLOPROVISIONING,
+        edit_cu_async_job = (self.common.modify_resource(category=SLOPROVISIONING,
                                                               resource_level=SYMMETRIX,
                                                               resource_level_id=self.array_id,
                                                               resource_type=FICON_SPLIT,
@@ -3001,6 +3001,6 @@ class ProvisioningFunctions(object):
                                                               resource_id=cu_ssid,
                                                               payload=edit_cu_data
                                                               ))
-        return self.conn.common.wait_for_job(
+        return self.common.wait_for_job(
             operation=operation, status_code=constants.STATUS_202,
             job=edit_cu_async_job)

--- a/PyU4V/provisioning.py
+++ b/PyU4V/provisioning.py
@@ -1555,7 +1555,7 @@ class ProvisioningFunctions(object):
             self, srp_id, sg_id, slo=None, workload=None,
             do_disable_compression=False, num_vols=0, vol_size=0,
             cap_unit='GB', allocate_full=False, _async=False,
-            vol_name=None, snapshot_policy_ids=None, enable_mobility_id=False):
+            vol_name=None, snapshot_policy_ids=None, enable_mobility_id=False, emulation_type='FBA'):
         """Create a storage group with optional volumes on create operation.
 
         :param srp_id: SRP id -- str
@@ -1573,6 +1573,7 @@ class ProvisioningFunctions(object):
                                     to associate with storage group -- list
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
+        :param emulation_type: device emulation type (CKD, FBA) -- str                           
         :returns: storage group details -- dict
         """
         srp_id = srp_id if srp_id else 'None'
@@ -1581,7 +1582,7 @@ class ProvisioningFunctions(object):
 
         payload = ({'srpId': srp_id,
                     'storageGroupId': sg_id,
-                    'emulation': 'FBA'})
+                    'emulation': emulation_type})
 
         volume_attributes = {'volume_size': str(vol_size),
                              'capacityUnit': cap_unit,
@@ -1659,7 +1660,7 @@ class ProvisioningFunctions(object):
     def create_non_empty_storage_group(
             self, srp_id, storage_group_id, service_level, workload, num_vols,
             vol_size, cap_unit, disable_compression=False, _async=False,
-            vol_name=None, snapshot_policy_ids=None, enable_mobility_id=False):
+            vol_name=None, snapshot_policy_ids=None, enable_mobility_id=False, emulation_type='FBA'):
         """Create a new storage group with the specified volumes.
 
         Generates a dictionary for json formatting and calls the create_sg
@@ -1681,6 +1682,7 @@ class ProvisioningFunctions(object):
                                     to associate with storage group -- list
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
+        :param emulation_type: device emulation type (CKD, FBA) -- str                                                      
         :returns: storage group details -- dict
         """
         return self.create_storage_group(
@@ -1689,7 +1691,8 @@ class ProvisioningFunctions(object):
             num_vols=num_vols, vol_size=vol_size, cap_unit=cap_unit,
             _async=_async, vol_name=vol_name,
             snapshot_policy_ids=snapshot_policy_ids,
-            enable_mobility_id=enable_mobility_id)
+            enable_mobility_id=enable_mobility_id,
+            emulation_type=emulation_type)
 
     @decorators.refactoring_notice(
         'ProvisioningFunctions',
@@ -1720,7 +1723,7 @@ class ProvisioningFunctions(object):
     def create_empty_storage_group(
             self, srp_id, storage_group_id, service_level, workload,
             disable_compression=False, _async=False,
-            snapshot_policy_ids=None):
+            snapshot_policy_ids=None, emulation_type='FBA'):
         """Create an empty storage group.
 
         Set the disable_compression flag for disabling compression on an All
@@ -1734,12 +1737,13 @@ class ProvisioningFunctions(object):
         :param _async: if call should be async -- bool
         :param snapshot_policy_ids: list of one or more snapshot policies
                                     to associate with storage group -- list
+        :param emulation_type: device emulation type (CKD, FBA) -- str                            
         :returns: storage group details -- dict
         """
         return self.create_storage_group(
             srp_id, storage_group_id, service_level, workload,
             do_disable_compression=disable_compression, _async=_async,
-            snapshot_policy_ids=snapshot_policy_ids)
+            snapshot_policy_ids=snapshot_policy_ids, emulation_type=emulation_type)
 
     def modify_storage_group(self, storage_group_id, payload):
         """Modify a storage group.
@@ -1859,7 +1863,7 @@ class ProvisioningFunctions(object):
             vol_name=None, create_new_volumes=None,
             remote_array_1_id=None, remote_array_1_sgs=None,
             remote_array_2_id=None, remote_array_2_sgs=None,
-            enable_mobility_id=False):
+            enable_mobility_id=False, emulation_type='FBA'):
         """Expand an existing storage group by adding new volumes.
 
         :param storage_group_id: storage group id -- str
@@ -1883,9 +1887,10 @@ class ProvisioningFunctions(object):
                                    -- str or list
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
+        :param emulation_type: device emulation type (CKD, FBA) -- str
         :returns: storage group details -- dict
         """
-        add_volume_param = {'emulation': 'FBA'}
+        add_volume_param = {'emulation': emulation_type }
 
         if not create_new_volumes:
             add_volume_param.update({'create_new_volumes': False})
@@ -2051,7 +2056,7 @@ class ProvisioningFunctions(object):
 
     def create_volume_from_storage_group_return_id(
             self, volume_name, storage_group_id, vol_size, cap_unit='GB',
-            enable_mobility_id=False):
+            enable_mobility_id=False, emulation_type='FBA'):
         """Create a new volume in the given storage group.
 
         :param volume_name: volume name -- str
@@ -2060,12 +2065,14 @@ class ProvisioningFunctions(object):
         :param cap_unit: capacity unit (MB, GB, TB, CYL) -- str
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
+        :param emulation_type: device emulation type (CKD, FBA) -- str                                   
         :returns: device id -- str
         """
         job = self.add_new_volume_to_storage_group(
             storage_group_id, 1, vol_size, cap_unit,
             _async=True, vol_name=volume_name,
-            enable_mobility_id=enable_mobility_id)
+            enable_mobility_id=enable_mobility_id,
+            emulation_type=emulation_type)
 
         task = self.common.wait_for_job('Create volume from storage group',
                                         202, job)

--- a/PyU4V/provisioning.py
+++ b/PyU4V/provisioning.py
@@ -1573,7 +1573,7 @@ class ProvisioningFunctions(object):
                                     to associate with storage group -- list
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
-        :param emulation_type: device emulation type (CKD, FBA) -- str                           
+        :param emulation_type: device emulation type (CKD, FBA) -- str
         :returns: storage group details -- dict
         """
         srp_id = srp_id if srp_id else 'None'
@@ -1682,7 +1682,7 @@ class ProvisioningFunctions(object):
                                     to associate with storage group -- list
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
-        :param emulation_type: device emulation type (CKD, FBA) -- str                                                      
+        :param emulation_type: device emulation type (CKD, FBA) -- str
         :returns: storage group details -- dict
         """
         return self.create_storage_group(
@@ -1737,7 +1737,7 @@ class ProvisioningFunctions(object):
         :param _async: if call should be async -- bool
         :param snapshot_policy_ids: list of one or more snapshot policies
                                     to associate with storage group -- list
-        :param emulation_type: device emulation type (CKD, FBA) -- str                            
+        :param emulation_type: device emulation type (CKD, FBA) -- str
         :returns: storage group details -- dict
         """
         return self.create_storage_group(
@@ -2065,7 +2065,7 @@ class ProvisioningFunctions(object):
         :param cap_unit: capacity unit (MB, GB, TB, CYL) -- str
         :param enable_mobility_id: enables unique volume WWN not tied to array
                                    serial number -- bool
-        :param emulation_type: device emulation type (CKD, FBA) -- str                                   
+        :param emulation_type: device emulation type (CKD, FBA) -- str
         :returns: device id -- str
         """
         job = self.add_new_volume_to_storage_group(

--- a/PyU4V/tests/unit_tests/test_pyu4v_provisioning.py
+++ b/PyU4V/tests/unit_tests/test_pyu4v_provisioning.py
@@ -1089,7 +1089,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
         with mock.patch.object(
                 self.provisioning, 'create_resource') as mock_create:
             self.provisioning.create_storage_group(
-                srp_id=self.data.srp, sg_id='new-sg', slo=None, workload=None, 
+                srp_id=self.data.srp, sg_id='new-sg', slo=None, workload=None,
                 cap_unit='CYL', emulation_type='CKD-3390')
 
             payload = {
@@ -1103,7 +1103,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
             mock_create.assert_called_once_with(
                 category='sloprovisioning',
                 resource_level='symmetrix', resource_level_id=self.data.array,
-                resource_type='storagegroup', payload=payload)   
+                resource_type='storagegroup', payload=payload)
 
     def test_create_storage_group_mobility_id(self):
         """Test create_storage_group no slo set."""
@@ -1384,7 +1384,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
             # 1 - no slo, not async
             self.provisioning.create_storage_group(
                 self.data.srp, 'LCU01', slo='Diamond', workload=None,
-                num_vols=1, vol_size='1113', vol_name='CKDTEST', 
+                num_vols=1, vol_size='1113', vol_name='CKDTEST',
                 cap_unit='CYL', emulation_type='CKD-3390')
             volume_identifier = {
                 'identifier_name': 'CKDTEST',
@@ -1405,7 +1405,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
             mock_create.assert_called_once_with(
                 category='sloprovisioning', resource_level='symmetrix',
                 resource_level_id=self.data.array,
-                resource_type='storagegroup', payload=payload1) 
+                resource_type='storagegroup', payload=payload1)
 
     def test_create_non_empty_storage_group(self):
         """Test create_non_empty_storage_group."""
@@ -1549,11 +1549,11 @@ class PyU4VProvisioningTest(testtools.TestCase):
                     'addVolumeParam': add_vol_info}}}
             mock_mod.assert_called_once_with(
                 self.data.storagegroup_name, payload)
-    
+
     def test_add_new_vol_to_storage_group_no_name_ckd(self):
         """Test add_new_vol_to_storage_group no vol name, not async, CKD emulation."""
         num_of_volumes = 1
-        volume_size = 1113 
+        volume_size = 1113
         volume_capacity_type = 'CYL'
         add_vol_info = {
             'emulation': 'CKD-3390',
@@ -1572,7 +1572,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
                 'expandStorageGroupParam': {
                     'addVolumeParam': add_vol_info}}}
             mock_mod.assert_called_once_with(
-                self.data.storagegroup_name, payload)   
+                self.data.storagegroup_name, payload)
 
     def test_add_new_vol_to_storage_group_mobility_id(self):
         """Test add_new_vol_to_storage_group no vol name, not async."""
@@ -1654,7 +1654,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
                 volume_capacity_type, True, volume_name,
                 emulation_type='CKD-3390')
             mock_mod.assert_called_once_with(
-                self.data.storagegroup_name, payload)    
+                self.data.storagegroup_name, payload)
 
     def test_add_new_vol_to_storage_group_srdf_multihop_srdf(self):
         """Test adding new volume to replicated storage group."""
@@ -2330,3 +2330,143 @@ class PyU4VProvisioningTest(testtools.TestCase):
         mck_sg_modify.assert_called_once_with(
             self.data.storagegroup_name,
             self.data.sg_expand_payload_basic_srdf)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'get_split_list',
+        return_value=list())
+    def test_get_split_list(self, mck_get_split_list):
+        """Test get_split_list."""
+        self.provisioning.get_split_list()
+        mck_get_split_list.assert_called_once()
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'get_split',
+        return_value=dict())
+    def test_get_split(self,mck_get_split):
+        """Test get_split with 'valid' split id."""
+        valid_split_id = 'Dummy'
+        self.provisioning.get_split(valid_split_id)
+        mck_get_split.assert_called_once_with(
+            valid_split_id)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'get_cu_image_list',
+        return_value=list())
+    def test_get_cu_image_list(self,mck_get_cu_image_list):
+        """Test get_cu_image_list with 'valid' split id."""
+        valid_split_id = 'Dummy'
+        self.provisioning.get_cu_image_list(valid_split_id)
+        mck_get_cu_image_list.assert_called_once_with(
+            valid_split_id)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'get_cu_image',
+        return_value=dict())
+    def test_get_cu_image(self,mck_get_cu_image):
+        """Test get_cu_image with 'valid' split id and CU image ssid."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        self.provisioning.get_cu_image(valid_split_id, valid_cu_ssid)
+        mck_get_cu_image.assert_called_once_with(
+            valid_split_id, valid_cu_ssid)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'create_cu_image',
+        return_value=None)
+    def test_create_cu_image(self,mck_create_cu_image):
+        """Test create_cu_image with 'valid' arguments."""
+        valid_split_id = 'Dummy'
+        valid_CU_number = '0x00'
+        valid_cu_ssid = '0xE000'
+        valid_cu_base = '0x00'
+        valid_vol_id ='00024'
+        self.provisioning.create_cu_image(
+            valid_split_id, valid_CU_number, valid_cu_ssid,
+             valid_cu_base, valid_vol_id)
+        mck_create_cu_image.assert_called_once_with(
+            valid_split_id, valid_CU_number, valid_cu_ssid,
+             valid_cu_base, valid_vol_id)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'get_cu_image_volumes',
+        return_value=list())
+    def test_get_cu_image_volumes(self,mck_get_cu_image_volumes):
+        """Test get_cu_image_volumes with 'valid' arguments."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        self.provisioning.get_cu_image_volumes(
+            valid_split_id,  valid_cu_ssid)
+        mck_get_cu_image_volumes.assert_called_once_with(
+            valid_split_id,  valid_cu_ssid)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'get_cu_image_volume',
+        return_value=dict())
+    def test_get_cu_image_volume(self,mck_get_cu_image_volume):
+        """Test get_cu_image_volume with 'valid' arguments."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        valid_vol_id = '00024'
+        self.provisioning.get_cu_image_volume(
+            valid_split_id,  valid_cu_ssid, valid_vol_id)
+        mck_get_cu_image_volume.assert_called_once_with(
+            valid_split_id,  valid_cu_ssid, valid_vol_id)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'modify_cu_image',
+        return_value=dict())
+    def test_modify_cu_image_assign_alias(self,mck_modify_cu_image_assign_alias):
+        """Test modify_cu_image - add an alias."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        modify_dict = {
+            'startAliasAddress': '0x00',
+            'endAliasAddress': '0xFF',
+        }
+        self.provisioning.modify_cu_image(
+            valid_split_id,  valid_cu_ssid, assign_alias_dict=modify_dict)
+        mck_modify_cu_image_assign_alias.assert_called_once_with(
+            valid_split_id,  valid_cu_ssid, assign_alias_dict=modify_dict)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'modify_cu_image',
+        return_value=dict())
+    def test_modify_cu_image_remove_alias(self,mck_modify_cu_image_remove_alias):
+        """Test modify_cu_image - remove an alias."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        modify_dict = {
+            'startAliasAddress': '0x00',
+            'endAliasAddress': '0xFF',
+        }
+        self.provisioning.modify_cu_image(
+            valid_split_id,  valid_cu_ssid, remove_alias_dict=modify_dict)
+        mck_modify_cu_image_remove_alias.assert_called_once_with(
+            valid_split_id,  valid_cu_ssid,remove_alias_dict=modify_dict)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'modify_cu_image',
+        return_value=dict())
+    def test_modify_cu_image_map_volume(self,mck_modify_cu_image_map_volume):
+        """Test modify_cu_image - map a volume."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        start_base_address = '0x00'
+        vol_list = ['00024']
+        self.provisioning.modify_cu_image(
+            valid_split_id,  valid_cu_ssid, map_start_address = start_base_address, map_volume_list=vol_list)
+        mck_modify_cu_image_map_volume.assert_called_once_with(
+            valid_split_id,  valid_cu_ssid,map_volume_list=vol_list)
+
+    @mock.patch.object(
+         provisioning.ProvisioningFunctions, 'modify_cu_image',
+        return_value=dict())
+    def test_modify_cu_image_map_volume(self,mck_modify_cu_image_unmap_volume):
+        """Test modify_cu_image - unmap a volume."""
+        valid_split_id = 'Dummy'
+        valid_cu_ssid = '0xE000'
+        vol_list = ['00024']
+        self.provisioning.modify_cu_image(
+            valid_split_id,  valid_cu_ssid, unmap_volume_list=vol_list)
+        mck_modify_cu_image_unmap_volume.assert_called_once_with(
+            valid_split_id,  valid_cu_ssid,unmap_volume_list=vol_list)

--- a/PyU4V/tests/unit_tests/test_pyu4v_provisioning.py
+++ b/PyU4V/tests/unit_tests/test_pyu4v_provisioning.py
@@ -1089,7 +1089,8 @@ class PyU4VProvisioningTest(testtools.TestCase):
         with mock.patch.object(
                 self.provisioning, 'create_resource') as mock_create:
             self.provisioning.create_storage_group(
-                srp_id=self.data.srp, sg_id='new-sg', slo=None, workload=None)
+                srp_id=self.data.srp, sg_id='new-sg', slo=None, workload=None, 
+                cap_unit='CYL', emulation_type='CKD-3390')
 
             payload = {
                 'srpId': 'SRP_1', 'storageGroupId': 'new-sg',
@@ -1383,7 +1384,8 @@ class PyU4VProvisioningTest(testtools.TestCase):
             # 1 - no slo, not async
             self.provisioning.create_storage_group(
                 self.data.srp, 'LCU01', slo='Diamond', workload=None,
-                num_vols=1, vol_size='1', vol_name='CKDTEST')
+                num_vols=1, vol_size='1113', vol_name='CKDTEST', 
+                cap_unit='CYL', emulation_type='CKD-3390')
             volume_identifier = {
                 'identifier_name': 'CKDTEST',
                 'volumeIdentifierChoice': 'identifier_name'}
@@ -1424,7 +1426,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
                 do_disable_compression=False,
                 num_vols=num_vols, vol_size=vol_size, cap_unit=cap_unit,
                 _async=False, enable_mobility_id=False, vol_name=None,
-                snapshot_policy_ids=None)
+                snapshot_policy_ids=None, emulation_type='FBA')
         act_result = self.provisioning.create_non_empty_storagegroup(
             srp_id, storage_group_id, slo, workload, num_vols, vol_size,
             cap_unit)
@@ -1450,7 +1452,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
                 do_disable_compression=False,
                 num_vols=num_vols, vol_size=vol_size, cap_unit=cap_unit,
                 _async=False, enable_mobility_id=True, vol_name=None,
-                snapshot_policy_ids=None)
+                snapshot_policy_ids=None, emulation_type='FBA')
         act_result = self.provisioning.create_non_empty_storage_group(
             srp_id, storage_group_id, slo, workload, num_vols, vol_size,
             cap_unit)
@@ -1470,7 +1472,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
             mock_create.assert_called_once_with(
                 srp_id, storage_group_id, slo, workload,
                 do_disable_compression=False, _async=False,
-                snapshot_policy_ids=None)
+                snapshot_policy_ids=None, emulation_type='FBA')
         act_result = self.provisioning.create_empty_sg(
             srp_id, storage_group_id, slo, workload)
         ref_result = self.data.job_list[0]
@@ -1563,9 +1565,9 @@ class PyU4VProvisioningTest(testtools.TestCase):
         with mock.patch.object(
                 self.provisioning, 'modify_storage_group') as mock_mod:
             # no vol name; not _async
-            self.provisioning.add_new_vol_to_storagegroup(
+            self.provisioning.add_new_volume_to_storage_group(
                 self.data.storagegroup_name, num_of_volumes, volume_size,
-                volume_capacity_type)
+                volume_capacity_type, emulation_type='CKD-3390')
             payload = {'editStorageGroupActionParam': {
                 'expandStorageGroupParam': {
                     'addVolumeParam': add_vol_info}}}
@@ -1625,7 +1627,7 @@ class PyU4VProvisioningTest(testtools.TestCase):
             mock_mod.assert_called_once_with(
                 self.data.storagegroup_name, payload)
 
-    def test_add_new_vol_to_storage_group_name_async(self):
+    def test_add_new_ckd_vol_to_storage_group_name_async(self):
         """Test add_new_vol_to_storage_group vol name, async, CKD emulation."""
         num_of_volumes = 1
         volume_size = 1113 # Model 1 3390
@@ -1647,9 +1649,10 @@ class PyU4VProvisioningTest(testtools.TestCase):
             'executionOption': 'ASYNCHRONOUS'}
         with mock.patch.object(
                 self.provisioning, 'modify_storage_group') as mock_mod:
-            self.provisioning.add_new_vol_to_storagegroup(
+            self.provisioning.add_new_volume_to_storage_group(
                 self.data.storagegroup_name, num_of_volumes, volume_size,
-                volume_capacity_type, True, volume_name)
+                volume_capacity_type, True, volume_name,
+                emulation_type='CKD-3390')
             mock_mod.assert_called_once_with(
                 self.data.storagegroup_name, payload)    
 
@@ -1715,7 +1718,8 @@ class PyU4VProvisioningTest(testtools.TestCase):
                 remote_array_1_id=self.data.remote_array,
                 remote_array_1_sgs=self.data.storagegroup_name,
                 remote_array_2_id=self.data.remote_array2,
-                remote_array_2_sgs=self.data.storagegroup_name)
+                remote_array_2_sgs=self.data.storagegroup_name,
+                emulation_type='CKD-3390')
             mock_mod.assert_called_once_with(
                 self.data.storagegroup_name, payload)
 

--- a/PyU4V/utils/constants.py
+++ b/PyU4V/utils/constants.py
@@ -85,6 +85,8 @@ REMOTE_PORT = 'remote_port'
 ALERT = 'alert'
 ALERT_SUMMARY = 'alert_summary'
 COMPLIANCE = 'compliance'
+FICON_SPLIT = 'split'
+CU_IMAGE = 'cuimage'
 
 # Status Codes
 STATUS_200 = 200


### PR DESCRIPTION
Add 'emulation_type' parameter to allow creation of 'mainframe' CKD storage groups and 'CKD' volumes.
The 'deprecated' versions of 'create_' functions have not been updated as they are being removed in a future version
This fixes dell#143 .